### PR TITLE
ECS Callback Patch  -> (details in description)

### DIFF
--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Archetype.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Archetype.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 #include "EcsUtils.h"
-
+#include "EventCallback.h"
 #include <assert.h>
 
 namespace Ecs
@@ -13,6 +13,8 @@ namespace Ecs
 		int full_chunks{0};
 		//full chunks allways on the start of the array
 		std::vector<DataChunk*> chunks{};
+		EventCallback addition_callbacks;
+		EventCallback deletion_callbacks;
 	};
 
 	//contains info for mapping which chunk an entity belongs to

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Component.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Component.h
@@ -167,4 +167,16 @@ namespace Ecs
 			return chunkOwner->header.last;
 		}
 	};
+
+
+	template<typename T>
+	struct ComponentEvent : public Ecs::internal::event::Event
+	{
+		T& component;
+		EntityID entityID;
+		ComponentEvent(EntityID eid, T& _component) 
+			: component{ _component }, entityID{ eid } {};
+	};
+
+	using TestComponentEvent = ComponentEvent<TestComponent>;
 }

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EcsCommon.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EcsCommon.h
@@ -3,6 +3,7 @@
 #include "Component.h"
 #include "Archetype.h"
 #include <algorithm>
+#include  <assert.h>
 namespace Ecs::internal
 {
 	//forward declarations
@@ -280,6 +281,12 @@ namespace Ecs::internal
 			Get_entity_component<C>(world, id) = comp;
 		}
 	}
+
+	/****************************
+	  event functions
+	****************************/
+
+
 
 
 }//namespace Ecs::internal

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EcsUtils.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EcsUtils.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <cstddef>
 #include <typeinfo>
+#include <utility>
+#include <concepts>
 namespace Ecs
 {
 	constexpr size_t BLOCK_MEMORY_16K = 16384;
@@ -63,4 +65,25 @@ namespace Ecs
 	};
 
 	struct TestComponent{};
+
+	
+}
+
+namespace Ecs::internal::event
+{
+	struct Event
+	{
+	protected:
+		virtual ~Event() {};
+	};
+
+}
+
+namespace Ecs
+{
+	struct EntityEvent : public internal::event::Event
+	{
+		EntityID entity;
+		EntityEvent(EntityID eid) : entity{ eid } {}
+	};
 }

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EventCallback.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EventCallback.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "EventFunction.h"
+#include <vector>
+#include <memory>
+#include <unordered_map>
+#include <typeindex>
+namespace Ecs
+{
+    class EventCallback
+    {
+    public:
+        using FunctionContainer = std::vector<std::unique_ptr<internal::EventFunctionBase>>;
+        using SubscriberContainer = std::unordered_map<std::type_index, FunctionContainer>;
+    protected:
+        SubscriberContainer m_subscribers;
+    private:
+        template<typename T>
+        inline std::type_index GetTypeIndex()
+        {
+            return typeid(T);
+        }
+
+        template<typename T>
+        SubscriberContainer::mapped_type& GetFunctionContainer()
+        {
+            if (m_subscribers.find(GetTypeIndex<T>()) == m_subscribers.end())
+                m_subscribers.emplace(GetTypeIndex<T>(), SubscriberContainer::mapped_type{});
+
+            return m_subscribers[GetTypeIndex<T>()];
+        }
+
+        template<typename T>
+        void RemoveFunctionContainer()
+        {
+            if (m_subscribers.find(GetTypeIndex<T>()) == m_subscribers.end())
+                return;
+            m_subscribers.erase(m_subscribers.find(GetTypeIndex<T>()));
+        }
+    public:
+        EventCallback() = default;
+        EventCallback(EventCallback const&) = delete;
+        EventCallback& operator=(EventCallback const&) = delete;
+
+
+        template<typename EventType>
+        void Broadcast(EventType* event)
+        {
+            auto& function_container = GetFunctionContainer<EventType>();
+
+            if (function_container.empty()) return;
+
+            for (auto& functions : function_container)
+                functions->Execute(event);
+        }
+        /*********************************************************************************//*!
+        \brief Registers a member function as a callback
+        \param instance instance to object on which to invoke the member function on
+        \param memberFunction pointer to member function
+        *//**********************************************************************************/
+        template<class T, class EventType>
+        void Subscribe(T* instance, typename internal::EventMemberFunction<T, EventType>::MemberFunctionPointer memberFunction)
+        {
+            if (m_subscribers.find(GetTypeIndex<EventType>()) == m_subscribers.end())
+                m_subscribers.emplace(GetTypeIndex<EventType>(), SubscriberContainer::mapped_type{});
+
+            auto& function_container = GetFunctionContainer<EventType>();
+            function_container.emplace_back(std::make_unique<internal::EventMemberFunction<T, EventType>>(instance, memberFunction));
+        }
+        /*********************************************************************************//*!
+        \brief Registers a static/non-member function as a callback
+        \param function pointer to static/non-member function
+        *//**********************************************************************************/
+        template<class EventType>
+        void Subscribe(typename internal::EventFunction<EventType>::FunctionPointer function)
+        {
+            if (m_subscribers.find(GetTypeIndex<EventType>()) == m_subscribers.end())
+                m_subscribers.emplace(GetTypeIndex<EventType>(), SubscriberContainer::mapped_type{});
+
+            auto& function_container = GetFunctionContainer<EventType>();
+            function_container.emplace_back(std::make_unique<internal::EventFunction<EventType>>(function));
+        }
+        /*********************************************************************************//*!
+        \brief Removes a registered member function aka callback
+        \param instance instance to object on which to invoke the member function on
+        \param memberFunction pointer to member function
+        *//**********************************************************************************/
+        template<class T, class EventType>
+        void Unsubscribe(T* instance, typename internal::EventMemberFunction<T, EventType>::MemberFunctionPointer memberFunction)
+        {
+            if (m_subscribers.find(GetTypeIndex<EventType>()) == m_subscribers.end())
+                return;
+
+            auto& function_container = GetFunctionContainer<EventType>();
+
+            internal::EventMemberFunction<T, EventType> callback{ instance, memberFunction };
+            std::size_t index = 0;
+            for (auto& function : function_container)
+            {
+                if ((*function) == callback)
+                {
+                    function_container.erase(function_container.begin() + index);
+                    break;
+                }
+                ++index;
+            }
+            if (function_container.empty())
+            {
+                RemoveFunctionContainer<EventType>();
+            }
+        }
+        /*********************************************************************************//*!
+        \brief Removes a static/non-member function aka callback
+        \param function pointer to static/non-member function
+        *//**********************************************************************************/
+        template<class EventType>
+        void Unsubscribe(typename internal::EventFunction<EventType>::FunctionPointer function)
+        {
+            if (m_subscribers.find(GetTypeIndex<EventType>()) == m_subscribers.end())
+                return;
+
+            auto& function_container = GetFunctionContainer<EventType>();
+
+            internal::EventFunction<EventType> callback{ function };
+            std::size_t index = 0;
+            for (auto& function : function_container)
+            {
+                if ((*function) == callback)
+                {
+                    function_container.erase(function_container.begin() + index);
+                    break;
+                }
+                ++index;
+            }
+            if (function_container.empty())
+            {
+                RemoveFunctionContainer<EventType>();
+            }
+        }
+    };
+}

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EventFunction.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EventFunction.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "EcsUtils.h"
+#include <functional>
+namespace Ecs::internal
+{
+class EventFunctionBase {
+    public:
+        // Call the member function
+        inline void Execute(event::Event* event){ Invoke(event); }
+        virtual ~EventFunctionBase() = default;
+    protected:
+        // Implemented by MemberFunctionHandler
+        virtual void Invoke(event::Event* event) = 0;
+    };
+
+
+    template<class T, class EventType>
+    class EventMemberFunction : public EventFunctionBase
+    {
+    public:
+        using ValueType = EventType;
+        using MemberFunctionPointer = void(T::*)(EventType*);
+
+        EventMemberFunction(T* instance, MemberFunctionPointer memberFunction) : m_instance{ instance }, m_memberFunction{ memberFunction } {};
+
+    protected:
+        void Invoke(event::Event* event) override
+        {
+            // Cast event to the correct type and call member function
+            std::invoke(m_memberFunction, m_instance, static_cast<EventType*>(event));
+        }
+
+        // Pointer to class instance
+        T* m_instance;
+
+        // Pointer to member function
+        MemberFunctionPointer m_memberFunction;
+    };
+
+    template<class EventType>
+    class EventFunction : public EventFunctionBase
+    {
+    public:
+        using ValueType = EventType;
+        using FunctionPointer = void(*)(EventType*);
+        EventFunction(FunctionPointer function) : m_function{ function } {};
+    private:
+        void Invoke(event::Event* event) override 
+        {
+            // Cast event to the correct type and call function
+            std::invoke(m_function, static_cast<EventType*>(event));
+        }
+        // Pointer to member function
+        FunctionPointer m_function;
+    };
+}

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/System.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/System.h
@@ -18,3 +18,12 @@ namespace Ecs
 		virtual void Run(ECSWorld* world) = 0;
 	};
 }
+
+namespace Ecs::internal
+{
+	class TestSystem : public System
+	{
+	public:
+		void Run(ECSWorld* world) override {}
+	};
+}

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/TemplateFunctions.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/TemplateFunctions.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#include "EcsCommon.h"
-namespace Ecs 
-{
-
-}

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Wrapper.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Wrapper.h
@@ -33,6 +33,18 @@ namespace Ecs
 	{
 		IECSWorld world;
 	public:
+		template<typename C>
+		using CompEventFnPtr = typename IECSWorld::CompEventFnPtr<C>;
+		template<typename T, typename C>
+		using CompEventMemberFnPtr = typename IECSWorld::CompEventMemberFnPtr<T,C>;
+
+
+		using FnPtr = typename IECSWorld::FnPtr;
+		template<typename T>
+		using MemberFnPtr = typename IECSWorld::MemberFnPtr<T>;
+
+
+
 		template<typename Func>
 		inline void for_each(IQuery& query, Func&& function)
 		{
@@ -103,11 +115,18 @@ namespace Ecs
 		std::vector<uint64_t> const componentHashes(EntityID id);
 
 		void destroy(EntityID eid);
-
-		template<typename S>
+		
+		/*template<typename S>
 		S* Add_System()
 		{
 			return world.Add_System<S>();
+		}*/
+
+		//adds a system, constructor arguements supported
+		template<typename S, typename... Args>
+		S* Add_System(Args&&... arguementList)
+		{
+			return world.Add_System<S, Args...>(std::forward<Args>(arguementList)...);
 		}
 
 		template<typename S>
@@ -115,5 +134,57 @@ namespace Ecs
 		{
 			return world.Get_System<S>();
 		}
+
+		template<typename S>
+		void Run_System()
+		{
+			world.Run_System<S>(this);
+		}
+
+		//requires type Ecs::EntityEvent* for the function's parameters
+		void SubscribeOnAddEntity(FnPtr function);
+		//requires type Ecs::EntityEvent* for the function's parameters
+		//T is member function's class
+		template<typename T>
+		void SubscribeOnAddEntity(T* instance, MemberFnPtr<T> function)
+		{
+			world.SubscribeOnAddEntity<T>(instance, function);
+		}
+
+		//requires type Ecs::EntityEvent* for the function's parameters
+		void SubscribeOnDestroyEntity(FnPtr function);
+		//requires type Ecs::EntityEvent* for the function's parameters
+		//T is member function's class
+		template<typename T>
+		void SubscribeOnDestroyEntity(T* instance, MemberFnPtr<T> function)
+		{
+			world.SubscribeOnDestroyEntity(instance, function);
+		}
+		//C is Component type
+		template<typename C>
+		void SubscribeOnAddComponent(CompEventFnPtr<C> function)
+		{
+			world.SubscribeOnAddComponent<C>(function);
+		}
+		//C is Component type
+		template<typename C>
+		void SubscribeOnRemoveComponent(CompEventFnPtr<C> function)
+		{
+			world.SubscribeOnRemoveComponent<C>(function);
+		}
+
+		//T is the type of the member function's class, C is Component type
+		template<typename T, typename C>
+		void SubscribeOnAddComponent(T* instance, CompEventMemberFnPtr<T, C> function)
+		{
+			world.SubscribeOnAddComponent<T,C>(instance, function);
+		}
+		//T is the type of the member function's class, C is Component type
+		template<typename T, typename C>
+		void SubscribeOnRemoveComponent(T* instance, CompEventMemberFnPtr<T, C> function)
+		{
+			world.SubscribeOnRemoveComponent<T, C>(instance, function);
+		}
+
 	};
 }

--- a/Editor/vendor/Archetypes_Ecs/premake5.lua
+++ b/Editor/vendor/Archetypes_Ecs/premake5.lua
@@ -1,6 +1,7 @@
 project "ECS"
     kind "StaticLib"
     language "C++"
+    cppdialect "C++20"
     staticruntime "off"
 
     -- output directory
@@ -19,12 +20,12 @@ project "ECS"
 
     filter "system:windows"
         systemversion "latest"
-        cppdialect "C++17"
+        cppdialect "C++20"
 
     filter "system:linux"
         pic "On"
         systemversion "latest"
-        cppdialect "C++17"
+        cppdialect "C++20"
 
     filter "configurations:Debug"
         runtime "Debug"


### PR DESCRIPTION
PATCH NOTES:

Adding your callbacks for entity creation and destruction now available through
SubscribeOnAddEntity & SubscribeOnDestroyEntity

Adding your callbacks for component addition and removal now available through
SubscribeOnAddComponent & SubscribeOnRemoveComponent

*NOTES: Member functions supported too!!! add the address of your class's instance
as the first parameter. Check the bottom of A_Ecs.cpp under the ECS project in the
solution for examples

*IMPORTANT: Creating or destroying entities, with related components does not trigger the 
component addition and removal callbacks, but do let me know if its more desired that way!!!

Systems:

Adding systems now supports constructor arguements
new Run_System function which essentially calls Get_System< S >()->Run(this)
for you so you can be more lazy

Additional notes:
ECS project premake settings have been updated to upgrade the project to run on C++20