### PR TITLE
updated ecs wrapper with new functionality

### DIFF
--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Wrapper.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Wrapper.h
@@ -57,6 +57,12 @@ namespace Ecs
 			world.for_each(std::forward<Func>(function));
 		}
 
+		template<typename Func>
+		inline void for_each_entity(IQuery& query, Func&& function)
+		{
+			world.for_each_entity(query, std::forward<Func>(function));
+		}
+
 		template<typename C>
 		void add_component(EntityID id, C& comp)
 		{


### PR DESCRIPTION
for_each_entity(query, function) allows for iteration where the function only takes in Ecs::EntityID as the only parameter, and is intended for when you need the entity ID as well as the component