### PR TITLE
Ecs type erasure functionality(details in description)

### DIFF
--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/A_Ecs.cpp
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/A_Ecs.cpp
@@ -1,4 +1,16 @@
 ﻿#include "A_Ecs.h"
+namespace Ecs::internal
+{
+	static const ComponentInfo* get_ComponentInfo_WithNameHash(size_t const hash) {
+		if (componentInfo_map.contains(hash) == false)
+		{
+			return nullptr;
+		}
+
+		return &(componentInfo_map[hash]);
+	}
+}
+
 
 namespace Ecs
 {
@@ -42,6 +54,24 @@ namespace Ecs
 
 		singleton_map.clear();
 	};
+
+	void* IECSWorld::get_component(EntityID const id, size_t const hash)
+	{
+		auto componentinfo = internal::get_ComponentInfo_WithNameHash(hash);
+		//verify if component info exists
+		assert(componentinfo != nullptr);
+
+		return componentinfo->get_component(*this, id);
+	}
+
+	GetCompFn* IECSWorld::get_component_Fn(size_t const hash)
+	{
+		auto componentinfo = internal::get_ComponentInfo_WithNameHash(hash);
+		//verify if component info exists
+		assert(componentinfo != nullptr);
+
+		return componentinfo->get_component;
+	}
 
 	size_t IECSWorld::get_num_components(EntityID id)
 	{
@@ -140,6 +170,16 @@ namespace Ecs
 	void ECSWorld::SubscribeOnDestroyEntity(FnPtr function)
 	{
 		world.SubscribeOnDestroyEntity(function);
+	}
+
+	void* ECSWorld::get_component(EntityID const id, size_t const hash)
+	{
+		return world.get_component(id, hash);
+	}
+
+	GetCompFn* ECSWorld::get_component_Fn(size_t const hash)
+	{
+		return world.get_component_Fn(hash);
 	}
 }
 

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/A_Ecs.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/A_Ecs.h
@@ -99,7 +99,6 @@ namespace Ecs::internal
 		return mt;
 	}
 
-
 	//reorder archetype with the fullness
 	inline void set_chunk_full(DataChunk* chunk) {
 
@@ -675,6 +674,13 @@ namespace Ecs::internal
 		return acrray[storage.chunkIndex];
 	}
 
+	template<typename C>
+	size_t get_component_name_hash()
+	{
+		auto comp_info = get_ComponentInfo<C>();
+		return comp_info->hash.name_hash;
+	}
+
 
 	template<typename C>
 	bool has_component(IECSWorld* world, EntityID id)
@@ -1180,6 +1186,18 @@ namespace Ecs
 	C& IECSWorld::get_component(EntityID id)
 	{
 		return internal::get_entity_component<C>(this, id);
+	}
+
+	template<typename C>
+	size_t IECSWorld::get_component_hash()
+	{
+		return internal::get_component_name_hash<C>();
+	}
+
+	template<typename C>
+	ComponentInfo const* IECSWorld::get_component_info() const
+	{
+		return internal::get_ComponentInfo<C>();
 	}
 
 	template<typename C>

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Component.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Component.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include "EcsUtils.h"
+//#include "World.h"
 
 #include <typeinfo>
 #include <vector>
@@ -38,6 +39,7 @@ namespace Ecs
 		using CopyConstructorFn = void(void* self, void* copy);
 		using MoveConstructorFn = void(void* self, void* other);
 		using MoveAssignmentFn = void(void* self, void* other);
+		using GetComponentFn = GetCompFn;
 
 		TypeHash hash{};
 
@@ -47,6 +49,7 @@ namespace Ecs
 		CopyConstructorFn* copy_constructor{ nullptr };
 		MoveConstructorFn* move_constructor{ nullptr };
 		MoveAssignmentFn*  move_assignment{ nullptr };
+		GetComponentFn* get_component{ nullptr };
 		uint16_t size{ 0 };
 		uint16_t align{ 0 };
 
@@ -102,6 +105,12 @@ namespace Ecs
 			{
 				T* ptr = static_cast<T*>(self);
 				*ptr = std::move(*(static_cast<T*>(other)));
+			};
+
+			info.get_component = [](IECSWorld& world, EntityID id)
+			{
+				T& comp = world.get_component<T>(id);
+				return static_cast<void*>(&comp);
 			};
 
 			return info;

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EcsUtils.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/EcsUtils.h
@@ -27,6 +27,8 @@ namespace Ecs
 	class ECSWorld;
 	class System;
 
+	using GetCompFn = void*(IECSWorld& world, EntityID id);
+
 	inline constexpr uint64_t hash_64_fnv1a(const char* key, const uint64_t len) {
 
 		uint64_t hash = 14695981039346656037ull;

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/World.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/World.h
@@ -82,6 +82,18 @@ namespace Ecs
 		template<typename C>
 		C& get_component(EntityID id);
 
+		template<typename C>
+		size_t get_component_hash();
+
+		template<typename C>
+		ComponentInfo const* get_component_info() const;
+
+		void* get_component(EntityID const id, size_t const hash);
+
+		GetCompFn* get_component_Fn(size_t const hash);
+
+
+
 		size_t get_num_components(EntityID id);
 
 		template<typename C>

--- a/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Wrapper.h
+++ b/Editor/vendor/Archetypes_Ecs/Archetypes_Ecs/src/Wrapper.h
@@ -29,7 +29,7 @@ namespace Ecs
 
 
 
-	class ECSWorld
+	class ECSWorld : private IECSWorld
 	{
 		IECSWorld world;
 	public:
@@ -43,6 +43,7 @@ namespace Ecs
 		template<typename T>
 		using MemberFnPtr = typename IECSWorld::MemberFnPtr<T>;
 
+		operator IECSWorld& () { return world; }
 
 		//supports functions of the format: exampleFunction(ComponentA&, ComponentB&,...)
 		template<typename Func>
@@ -97,6 +98,22 @@ namespace Ecs
 		{
 			return world.get_component<C>(id);
 		}
+
+		template<typename C>
+		size_t get_component_hash()
+		{
+			return world.get_component_hash<C>();
+		}
+
+		template<typename C>
+		ComponentInfo const* get_component_info() const
+		{
+			return world.get_component_info<C>();
+		}
+
+		void* get_component(EntityID const id, size_t const hash);
+
+		GetCompFn* get_component_Fn(size_t const hash);
 
 		size_t get_num_components(EntityID id)
 		{


### PR DESCRIPTION
get_component_info< T >() - gets the component info struct which stores information about the component

size_t get_component_hash< T >() - gets the hash of the component

get_component(EntityID const id, size_t const hash) - get component as void ptr via the hash of the component,i.e non templated get component

get_component_Fn(size_t const hash) - function pointer to a function that gets component as a void ptr given  reference to ecs world and entity id