### PR TITLE
physx - fixed changing of rigidbody type during runtime

### DIFF
--- a/Editor/vendor/physx/Physics/Source/phy.cpp
+++ b/Editor/vendor/physx/Physics/Source/phy.cpp
@@ -1080,16 +1080,16 @@ namespace myPhysx
 /*-----------------------------------------------------------------------------*/
 /*                           EVENT CALLBACK                                    */
 /*-----------------------------------------------------------------------------*/
-    void EventCallBack::onConstraintBreak(PxConstraintInfo* constraints, PxU32 count) {
+    void EventCallBack::onConstraintBreak(PxConstraintInfo* /*constraints*/, PxU32 /*count*/) {
         printf("CALLBACK: onConstraintBreak\n");
     }
-    void EventCallBack::onWake(PxActor** actors, PxU32 count) {
+    void EventCallBack::onWake(PxActor** /*actors*/, PxU32 /*count*/) {
         printf("CALLBACK: onWake\n");
     }
-    void EventCallBack::onSleep(PxActor** actors, PxU32 count) {
+    void EventCallBack::onSleep(PxActor** /*actors*/, PxU32 /*count*/) {
         printf("CALLBACK: onSleep\n");
     }
-    void EventCallBack::onContact(const PxContactPairHeader& pairHeader, const PxContactPair* pairs, PxU32 count) {
+    void EventCallBack::onContact(const PxContactPairHeader& /*pairHeader*/, const PxContactPair* pairs, PxU32 count) {
         printf("CALLBACK: onContact -- ");
         printf("PAIRS: %d\n", count);
 
@@ -1206,7 +1206,7 @@ namespace myPhysx
             //}
         }
     }
-    void EventCallBack::onAdvance(const PxRigidBody* const* bodyBuffer, const PxTransform* poseBuffer, const PxU32 count) {
+    void EventCallBack::onAdvance(const PxRigidBody* const* /*bodyBuffer*/, const PxTransform* /*poseBuffer*/, const PxU32 /*count*/) {
         printf("CALLBACK: onAdvance\n");
     }
 }

--- a/Editor/vendor/physx/Physics/Source/phy.h
+++ b/Editor/vendor/physx/Physics/Source/phy.h
@@ -256,6 +256,9 @@ namespace myPhysx {
         void addTorque(PxVec3 f_amount, force f);
 
         // set default value for each type of shape & can change shape too
+        template<typename Type>
+        void reAttachShape(rigid rigidType, Type data);
+
         void setShape(shape shape);
         void removeShape();
 


### PR DESCRIPTION
Changing of rigidbody dynamic <-->  static during runtime
Reattach back the shape collider to the object since it's an unique shape - cannot be attach to another actor(object)