### PR TITLE
Scripting Improvements

### DIFF
--- a/Editor/src/App/Editor/Properties/SerializerScriptingProperties.cpp
+++ b/Editor/src/App/Editor/Properties/SerializerScriptingProperties.cpp
@@ -98,6 +98,14 @@ SerializerScriptingSaveProperties::SerializerScriptingSaveProperties()
 			//rapidjson::Value data(static_cast<uint64_t>((id.GetUUID())));//save as int64
 			val.AddMember(name, data, doc.GetAllocator());
 		});
+    m_ScriptSave.emplace(oo::ScriptValue::type_enum::PREFAB, [](rapidjson::Document& doc, rapidjson::Value& val, oo::ScriptFieldInfo& sfi)
+        {
+            rapidjson::Value name;
+            name.SetString(sfi.name.c_str(), doc.GetAllocator());
+            rapidjson::Value data;
+            data.SetString(sfi.value.GetValue<oo::ScriptValue::prefab_type>().filePath.c_str(), doc.GetAllocator());
+            val.AddMember(name, data, doc.GetAllocator());
+        });
 	m_ScriptSave.emplace(oo::ScriptValue::type_enum::FUNCTION, [this](rapidjson::Document& doc, rapidjson::Value& val, oo::ScriptFieldInfo& sfi)
 		{
 			rapidjson::Value name;
@@ -205,6 +213,10 @@ SerializerScriptingLoadProperties::SerializerScriptingLoadProperties()
 			oo::UUID id = val.GetUint64();
 			sfi.value.GetValue<oo::ScriptValue::component_type>().m_objID = id;
 		});
+    m_ScriptLoad.emplace(oo::ScriptValue::type_enum::PREFAB, [](rapidjson::Value&& val, oo::ScriptFieldInfo& sfi)
+        {
+            sfi.value.SetValue(oo::ScriptValue::prefab_type(val.GetString()));
+        });
 	m_ScriptLoad.emplace(oo::ScriptValue::type_enum::GAMEOBJECT, [](rapidjson::Value&& val, oo::ScriptFieldInfo& sfi)
 		{
 			oo::UUID id = val.GetUint64();

--- a/Editor/src/Ouroboros/API/GameObjectAPI.h
+++ b/Editor/src/Ouroboros/API/GameObjectAPI.h
@@ -41,6 +41,11 @@ namespace oo
         return uuid.GetUUID();
     }
 
+    SCRIPT_API bool CheckValidPrefabPath(const char* filePath)
+    {
+        return std::filesystem::exists(Project::GetPrefabFolder() / filePath);
+    }
+
     SCRIPT_API ComponentDatabase::IntPtr InstantiatePrefab(Scene::ID_type sceneID, const char* filePath, oo::UUID parentID)
     {
         std::shared_ptr<Scene> scene = ScriptManager::GetScene(sceneID);

--- a/Editor/src/Ouroboros/API/ScriptingAPI.h
+++ b/Editor/src/Ouroboros/API/ScriptingAPI.h
@@ -154,20 +154,4 @@ namespace oo
             ScriptEngine::ThrowNullException();
         scene->GetWorld().Get_System<ScriptSystem>()->RemoveComponent(uuid, name_space, name);
     }
-
-    SCRIPT_API bool CheckComponentEnabled(Scene::ID_type sceneID, oo::UUID uuid, const char* name_space, const char* name)
-    {
-        std::shared_ptr<Scene> scene = ScriptManager::GetScene(sceneID);
-        if (scene->FindWithInstanceID(uuid) == nullptr)
-            ScriptEngine::ThrowNullException();
-        return scene->GetWorld().Get_System<ScriptSystem>()->CheckComponentEnabled(uuid, name_space, name);
-    }
-
-    SCRIPT_API void SetComponentEnabled(Scene::ID_type sceneID, oo::UUID uuid, const char* name_space, const char* name, bool active)
-    {
-        std::shared_ptr<Scene> scene = ScriptManager::GetScene(sceneID);
-        if (scene->FindWithInstanceID(uuid) == nullptr)
-            ScriptEngine::ThrowNullException();
-        scene->GetWorld().Get_System<ScriptSystem>()->SetComponentEnabled(uuid, name_space, name, active);
-    }
 }

--- a/Editor/src/Ouroboros/Scripting/ScriptManager.cpp
+++ b/Editor/src/Ouroboros/Scripting/ScriptManager.cpp
@@ -69,11 +69,17 @@ namespace oo
             LOG_ERROR(e.what());
             return false;
         }
-        DisplayWarnings();
         if (DisplayErrors())
+        {
+            DisplayWarnings();
             return false;
-        LOG_CORE_TRACE("Script Compiling Successful");
-        return true;
+        }
+        else
+        {
+            LOG_CORE_TRACE("Script Compiling Successful");
+            DisplayWarnings();
+            return true;
+        }
     }
     void ScriptManager::Load()
     {

--- a/Editor/src/Ouroboros/Scripting/ScriptManager.h
+++ b/Editor/src/Ouroboros/Scripting/ScriptManager.h
@@ -175,25 +175,6 @@ namespace oo
                 std::shared_ptr<GameObject> obj = scene.FindWithInstanceID(uuid);
                 return obj->HasComponent<T>();
             };
-            ComponentDatabase::ComponentSetAction setEnabled = [](ComponentDatabase::SceneID sceneID, ComponentDatabase::UUID uuid, bool isEnabled)
-            {
-                //std::weak_ptr<IScene> scene_weak = s_SceneManager->GetScene(static_cast<IScene::ID_type>(sceneID));
-                //if (scene_weak.expired())
-                //    return;
-                //Scene& scene = *(std::dynamic_pointer_cast<Scene>(scene_weak.lock()).get());
-                //std::shared_ptr<GameObject> obj = scene.FindWithInstanceID(uuid);
-                //obj->GetComponent<T>().SetActive(isEnabled);
-            };
-            ComponentDatabase::ComponentCheck isEnabled = [](ComponentDatabase::SceneID sceneID, ComponentDatabase::UUID uuid)
-            {
-                //std::weak_ptr<IScene> scene_weak = s_SceneManager->GetScene(static_cast<IScene::ID_type>(sceneID));
-                //if (scene_weak.expired())
-                //    return false;
-                //Scene& scene = *(std::dynamic_pointer_cast<Scene>(scene_weak.lock()).get());
-                //std::shared_ptr<GameObject> obj = scene.FindWithInstanceID(uuid);
-                //return obj->GetComponent<T>().IsActive();
-                return true;
-            };
             ComponentDatabase::ComponentAction remove = [](ComponentDatabase::SceneID sceneID, ComponentDatabase::UUID uuid)
             {
                 std::weak_ptr<IScene> scene_weak = s_SceneManager->GetScene(static_cast<IScene::ID_type>(sceneID));
@@ -203,7 +184,7 @@ namespace oo
                 std::shared_ptr<GameObject> obj = scene.FindWithInstanceID(uuid);
                 return obj->RemoveComponent<T>();
             };
-            ComponentDatabase::RegisterComponent(name_space, name, add, remove, has, setEnabled, isEnabled);
+            ComponentDatabase::RegisterComponent(name_space, name, add, remove, has);
         }
 
     };

--- a/Editor/src/Ouroboros/Scripting/ScriptSystem.cpp
+++ b/Editor/src/Ouroboros/Scripting/ScriptSystem.cpp
@@ -28,6 +28,9 @@ namespace oo
     ScriptSystem::ScriptSystem(Scene& scene, ScriptDatabase& scripts, ComponentDatabase& components)
     : scene{ scene }, scriptDatabase{ scripts }, componentDatabase{ components }, isPlaying{ false }
     {
+        EventManager::Subscribe<ScriptSystem, WindowFocusEvent>(this, &ScriptSystem::OnApplicationFocus);
+        EventManager::Subscribe<ScriptSystem, WindowLoseFocusEvent>(this, &ScriptSystem::OnApplicationPause);
+
         EventManager::Subscribe<ScriptSystem, GameObjectComponent::OnEnableEvent>(this, &ScriptSystem::OnObjectEnabled);
         EventManager::Subscribe<ScriptSystem, GameObjectComponent::OnDisableEvent>(this, &ScriptSystem::OnObjectDisabled);
         EventManager::Subscribe<ScriptSystem, GameObject::OnDestroy>(this, &ScriptSystem::OnObjectDestroyed);
@@ -39,6 +42,9 @@ namespace oo
 
     ScriptSystem::~ScriptSystem()
     {
+        EventManager::Unsubscribe<ScriptSystem, WindowFocusEvent>(this, &ScriptSystem::OnApplicationFocus);
+        EventManager::Unsubscribe<ScriptSystem, WindowLoseFocusEvent>(this, &ScriptSystem::OnApplicationPause);
+
         EventManager::Unsubscribe<ScriptSystem, GameObjectComponent::OnEnableEvent>(this, &ScriptSystem::OnObjectEnabled);
         EventManager::Unsubscribe<ScriptSystem, GameObjectComponent::OnDisableEvent>(this, &ScriptSystem::OnObjectDisabled);
         EventManager::Unsubscribe<ScriptSystem, GameObject::OnDestroy>(this, &ScriptSystem::OnObjectDestroyed);
@@ -401,6 +407,19 @@ namespace oo
                 fieldInfo.SetScriptReference(field, scriptPtr);
             }
         }
+    }
+
+    void ScriptSystem::OnApplicationFocus(WindowFocusEvent* e)
+    {
+        if (!isPlaying)
+            return;
+        InvokeForAllEnabled("OnApplicationFocus");
+    }
+    void ScriptSystem::OnApplicationPause(WindowLoseFocusEvent* e)
+    {
+        if (!isPlaying)
+            return;
+        InvokeForAllEnabled("OnApplicationPause");
     }
 
     void ScriptSystem::OnObjectEnabled(GameObjectComponent::OnEnableEvent* e)

--- a/Editor/src/Ouroboros/Scripting/ScriptSystem.cpp
+++ b/Editor/src/Ouroboros/Scripting/ScriptSystem.cpp
@@ -246,18 +246,6 @@ namespace oo
             return;
         componentDatabase.Delete(uuid, name_space, name);
     }
-    void ScriptSystem::SetComponentEnabled(ComponentDatabase::UUID uuid, const char* name_space, const char* name, bool isEnabled)
-    {
-        if (!isPlaying)
-            return;
-        componentDatabase.SetEnabled(uuid, name_space, name, isEnabled);
-    }
-    bool ScriptSystem::CheckComponentEnabled(ComponentDatabase::UUID uuid, const char* name_space, const char* name)
-    {
-        if (!isPlaying)
-            return false;
-        return componentDatabase.CheckEnabled(uuid, name_space, name);
-    }
 
     ComponentDatabase::IntPtr ScriptSystem::GetGameObject(ComponentDatabase::UUID uuid)
     {

--- a/Editor/src/Ouroboros/Scripting/ScriptSystem.h
+++ b/Editor/src/Ouroboros/Scripting/ScriptSystem.h
@@ -52,8 +52,6 @@ namespace oo
         ComponentDatabase::IntPtr GetComponent(ComponentDatabase::UUID uuid, const char* name_space, const char* name);
         ComponentDatabase::IntPtr HasActualComponent(ComponentDatabase::UUID uuid, const char* name_space, const char* name);
         void RemoveComponent(ComponentDatabase::UUID uuid, const char* name_space, const char* name);
-        void SetComponentEnabled(ComponentDatabase::UUID uuid, const char* name_space, const char* name, bool isEnabled);
-        bool CheckComponentEnabled(ComponentDatabase::UUID uuid, const char* name_space, const char* name);
 
         ComponentDatabase::IntPtr GetGameObject(ComponentDatabase::UUID uuid);
 

--- a/Editor/src/Ouroboros/Scripting/ScriptSystem.h
+++ b/Editor/src/Ouroboros/Scripting/ScriptSystem.h
@@ -23,6 +23,7 @@ Technology is prohibited.
 #include "Ouroboros/ECS/GameObject.h"
 
 #include "Ouroboros/Physics/PhysicsEvents.h"
+#include "Ouroboros/Core/Events/ApplicationEvent.h"
 
 namespace oo
 {
@@ -69,6 +70,9 @@ namespace oo
 
         void UpdateAllScriptFieldsWithInfo();
         void UpdateScriptFieldsWithInfo(oo::UUID uuid, ScriptComponent& script);
+
+        void OnApplicationFocus(WindowFocusEvent* e);
+        void OnApplicationPause(WindowLoseFocusEvent* e);
 
         void OnObjectEnabled(GameObjectComponent::OnEnableEvent* e);
         void OnObjectDisabled(GameObjectComponent::OnDisableEvent* e);

--- a/Editor/src/Ouroboros/Scripting/ScriptValue.cpp
+++ b/Editor/src/Ouroboros/Scripting/ScriptValue.cpp
@@ -743,13 +743,19 @@ namespace oo
                 [](MonoObject* obj, MonoClassField* field, ScriptValue const& value)
                 {
                     ScriptValue::prefab_type prefab = value.GetValue<ScriptValue::prefab_type>();
+                    if (prefab.filePath.size() <= 0)
+                    {
+                        mono_field_set_value(obj, field, nullptr);
+                        return;
+                    }
+
                     MonoClass* prefabClass = ScriptEngine::GetClass("ScriptCore", "Ouroboros", "Prefab");
                     MonoObject* fieldValue = ScriptEngine::CreateObject(prefabClass);
 
                     MonoString* pathString = ScriptEngine::CreateString(prefab.filePath.c_str());
                     MonoClassField* pathField = mono_class_get_field_from_name(prefabClass, "filePath");
                     mono_field_set_value(fieldValue, pathField, pathString);
-                    mono_field_set_value(obj, field, mono_object_unbox(fieldValue));
+                    mono_field_set_value(obj, field, fieldValue);
                 },
                 // GetFieldValue
                 [](MonoObject* object, MonoClassField* field, ScriptValue const& refInfo)
@@ -1120,8 +1126,6 @@ namespace oo
                 return type_enum::VECTOR3;
             //if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Colour")) // Colour
             //    return type_enum::COLOUR;
-            if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Prefab")) // Prefab
-                return type_enum::PREFAB;
             return type_enum::EMPTY;
         }
         case MONO_TYPE_CLASS:
@@ -1143,6 +1147,8 @@ namespace oo
                 return type_enum::COMPONENT;
             //if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Asset")) // is an Asset
             //    return type_enum::ASSET;
+            if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Prefab")) // is a Prefab
+                return type_enum::PREFAB;
             if (ScriptEngine::CheckTypeHasAttribute(type, serializableType)) // is a container for info
                 return type_enum::CLASS;
             return type_enum::EMPTY;

--- a/Editor/src/Ouroboros/Scripting/ScriptValue.cpp
+++ b/Editor/src/Ouroboros/Scripting/ScriptValue.cpp
@@ -736,79 +736,76 @@ namespace oo
         //        }
         //    }
         //},
-        //{ 
-        //    ScriptValue::type_enum::PREFAB, ScriptValue::helper_functions
-        //    {
-        //        // SetFieldValue
-        //        [](MonoObject* obj, MonoClassField* field, ScriptValue const& value)
-        //        {
-        //            ScriptValue::prefab_type prefab = value.GetValue<ScriptValue::prefab_type>();
-        //            MonoClass* prefabClass = ScriptEngine::GetClass("ScriptCore", "Ouroboros", "Prefab");
-        //            MonoObject* fieldValue = ScriptEngine::CreateObject(prefabClass);
+        { 
+            ScriptValue::type_enum::PREFAB, ScriptValue::helper_functions
+            {
+                // SetFieldValue
+                [](MonoObject* obj, MonoClassField* field, ScriptValue const& value)
+                {
+                    ScriptValue::prefab_type prefab = value.GetValue<ScriptValue::prefab_type>();
+                    MonoClass* prefabClass = ScriptEngine::GetClass("ScriptCore", "Ouroboros", "Prefab");
+                    MonoObject* fieldValue = ScriptEngine::CreateObject(prefabClass);
 
-        //            MonoString* pathString = ScriptEngine::CreateString(prefab.filePath.c_str());
-        //            MonoClassField* pathField = mono_class_get_field_from_name(prefabClass, "filePath");
-        //            mono_field_set_value(fieldValue, pathField, pathString);
+                    MonoString* pathString = ScriptEngine::CreateString(prefab.filePath.c_str());
+                    MonoClassField* pathField = mono_class_get_field_from_name(prefabClass, "filePath");
+                    mono_field_set_value(fieldValue, pathField, pathString);
+                    mono_field_set_value(obj, field, mono_object_unbox(fieldValue));
+                },
+                // GetFieldValue
+                [](MonoObject* object, MonoClassField* field, ScriptValue const& refInfo)
+                {
+                    MonoType* type = mono_field_get_type(field);
+                    MonoClass* typeClass = mono_type_get_class(type);
+                    MonoObject* fieldObj = mono_field_get_value_object(mono_domain_get(), field, object);
+                    std::string filePath = "";
+                    if (fieldObj != nullptr)
+                    {
+                        MonoClassField* pathField = mono_class_get_field_from_name(typeClass, "filePath");
+                        MonoString* pathString;
+                        mono_field_get_value(fieldObj, pathField, &pathString);
+                        if (pathString != nullptr)
+                        {
+                            filePath = mono_string_to_utf8(pathString);
+                        }
+                    }
+                    return ScriptValue(ScriptValue::prefab_type{ filePath });
+                },
+                // GetObjectValue
+                [](MonoObject* object, ScriptValue const& refInfo)
+                {
+                    std::string filePath = "";
+                    if (object != nullptr)
+                    {
+                        MonoClass* objClass = mono_object_get_class(object);
+                        MonoClassField* pathField = mono_class_get_field_from_name(objClass, "filePath");
+                        MonoString* pathString;
+                        mono_field_get_value(object, pathField, &pathString);
+                        if (pathString != nullptr)
+                        {
+                            filePath = mono_string_to_utf8(pathString);
+                        }
+                    }
+                    return ScriptValue(ScriptValue::prefab_type{ filePath });
+                },
+                // AddToList
+                [](MonoObject* list, MonoClass* elementClass, ScriptValue const& value)
+                {
+                    MonoMethod* addMethod = mono_class_get_method_from_name(mono_object_get_class(list), "Add", 1);
 
-        //            ScriptEngine::InvokeFunction(fieldValue, "LoadSourceObject");
-        //            mono_field_set_value(obj, field, fieldValue);
-        //        },
-        //        // GetFieldValue
-        //        [](MonoObject* object, MonoClassField* field, ScriptValue const& refInfo)
-        //        {
-        //            MonoType* type = mono_field_get_type(field);
-        //            MonoClass* typeClass = mono_type_get_class(type);
-        //            MonoObject* fieldObj = mono_field_get_value_object(mono_domain_get(), field, object);
-        //            std::string filePath = "";
-        //            if (fieldObj != nullptr)
-        //            {
-        //                MonoClassField* pathField = mono_class_get_field_from_name(typeClass, "filePath");
-        //                MonoString* pathString;
-        //                mono_field_get_value(fieldObj, pathField, &pathString);
-        //                if (pathString != nullptr)
-        //                {
-        //                    filePath = mono_string_to_utf8(pathString);
-        //                }
-        //            }
-        //            return ScriptValue(ScriptValue::prefab_type{ filePath });
-        //        },
-        //        // GetObjectValue
-        //        [](MonoObject* object, ScriptValue const& refInfo)
-        //        {
-        //            std::string filePath = "";
-        //            if (object != nullptr)
-        //            {
-        //                MonoClass* objClass = mono_object_get_class(object);
-        //                MonoClassField* pathField = mono_class_get_field_from_name(objClass, "filePath");
-        //                MonoString* pathString;
-        //                mono_field_get_value(object, pathField, &pathString);
-        //                if (pathString != nullptr)
-        //                {
-        //                    filePath = mono_string_to_utf8(pathString);
-        //                }
-        //            }
-        //            return ScriptValue(ScriptValue::prefab_type{ filePath });
-        //        },
-        //        // AddToList
-        //        [](MonoObject* list, MonoClass* elementClass, ScriptValue const& value)
-        //        {
-        //            MonoMethod* addMethod = mono_class_get_method_from_name(mono_object_get_class(list), "Add", 1);
+                    ScriptValue::prefab_type prefab = value.GetValue<ScriptValue::prefab_type>();
+                    MonoClass* prefabClass = ScriptEngine::GetClass("ScriptCore", "Ouroboros", "Prefab");
+                    MonoObject* entry = ScriptEngine::CreateObject(prefabClass);
 
-        //            ScriptValue::prefab_type prefab = value.GetValue<ScriptValue::prefab_type>();
-        //            MonoClass* prefabClass = ScriptEngine::GetClass("ScriptCore", "Ouroboros", "Prefab");
-        //            MonoObject* entry = ScriptEngine::CreateObject(prefabClass);
+                    MonoString* pathString = ScriptEngine::CreateString(prefab.filePath.c_str());
+                    MonoClassField* pathField = mono_class_get_field_from_name(prefabClass, "filePath");
+                    mono_field_set_value(entry, pathField, pathString);
 
-        //            MonoString* pathString = ScriptEngine::CreateString(prefab.filePath.c_str());
-        //            MonoClassField* pathField = mono_class_get_field_from_name(prefabClass, "filePath");
-        //            mono_field_set_value(entry, pathField, pathString);
-        //            ScriptEngine::InvokeFunction(entry, "LoadSourceObject");
-
-        //            void* args[1];
-        //            args[0] = entry;
-        //            mono_runtime_invoke(addMethod, list, args, NULL);
-        //        }
-        //    }
-        //},
+                    void* args[1];
+                    args[0] = entry;
+                    mono_runtime_invoke(addMethod, list, args, NULL);
+                }
+            }
+        },
         { 
             ScriptValue::type_enum::CLASS, ScriptValue::helper_functions
             {
@@ -1123,6 +1120,8 @@ namespace oo
                 return type_enum::VECTOR3;
             //if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Colour")) // Colour
             //    return type_enum::COLOUR;
+            if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Prefab")) // Prefab
+                return type_enum::PREFAB;
             return type_enum::EMPTY;
         }
         case MONO_TYPE_CLASS:
@@ -1144,8 +1143,6 @@ namespace oo
                 return type_enum::COMPONENT;
             //if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Asset")) // is an Asset
             //    return type_enum::ASSET;
-            //if (ScriptEngine::CheckClassInheritance(typeClass, "ScriptCore", "Ouroboros", "Prefab")) // is a Prefab
-            //    return type_enum::PREFAB;
             if (ScriptEngine::CheckTypeHasAttribute(type, serializableType)) // is a container for info
                 return type_enum::CLASS;
             return type_enum::EMPTY;
@@ -1310,9 +1307,9 @@ namespace oo
         //    }
         //}
         //break;
-        //case ScriptValue::type_enum::PREFAB:
-        //    valueList.emplace_back(ScriptValue::prefab_type{ "" });
-        //    break;
+        case ScriptValue::type_enum::PREFAB:
+            valueList.emplace_back(ScriptValue::prefab_type{ "" });
+            break;
         case ScriptValue::type_enum::CLASS:
         {
             ScriptClassInfo classInfo{ name_space, name };

--- a/Editor/src/Ouroboros/Scripting/ScriptValue.h
+++ b/Editor/src/Ouroboros/Scripting/ScriptValue.h
@@ -24,8 +24,7 @@ Technology is prohibited.
 
 #include "Scripting/ScriptEngine.h"
 
-//#include "../Asset/Asset.h"
-//#include "../Asset/AssetTypes.h"
+#include "Ouroboros/Asset/Asset.h"
 #include "Ouroboros/ECS/GameObject.h"
 
 namespace oo
@@ -49,7 +48,7 @@ namespace oo
             //COLOUR,
             GAMEOBJECT,
             COMPONENT,
-            //ASSET,
+            ASSET,
             PREFAB,
             CLASS,
             LIST,
@@ -105,14 +104,6 @@ namespace oo
 
             bool is_valid();
         };
-
-        // used to store the necessary info to create a generic C# Asset
-        //struct asset_type
-        //{
-        //public:
-        //    AssetType type;
-        //    AssetHandle handle;
-        //};
 
         // used to store the necessary info to create a C# prefab reference
         struct prefab_type
@@ -213,7 +204,7 @@ namespace oo
             //oo::Colour,
             UUID,
             component_type,
-            //asset_type,
+            Asset,
             prefab_type,
             class_type,
             list_type,

--- a/Editor/src/Ouroboros/Scripting/ScriptValue.h
+++ b/Editor/src/Ouroboros/Scripting/ScriptValue.h
@@ -50,7 +50,7 @@ namespace oo
             GAMEOBJECT,
             COMPONENT,
             //ASSET,
-            //PREFAB,
+            PREFAB,
             CLASS,
             LIST,
             FUNCTION,
@@ -115,11 +115,11 @@ namespace oo
         //};
 
         // used to store the necessary info to create a C# prefab reference
-        //struct prefab_type
-        //{
-        //public:
-        //    std::string filePath; // local file path, will prepend prefab file path later
-        //};
+        struct prefab_type
+        {
+        public:
+            std::string filePath; // local file path, will prepend prefab file path later
+        };
 
         // used to store the necessary info to create a C# data container
         struct class_type
@@ -214,7 +214,7 @@ namespace oo
             UUID,
             component_type,
             //asset_type,
-            //prefab_type,
+            prefab_type,
             class_type,
             list_type,
             function_type

--- a/Editor/vendor/scriptcore/src/ScriptCore/Components/Component.cs
+++ b/Editor/vendor/scriptcore/src/ScriptCore/Components/Component.cs
@@ -9,31 +9,6 @@ namespace Ouroboros
         private GameObject m_GameObject = null;
         private int m_ComponentID = -1;
 
-        [DllImport("__Internal")] private static extern bool CheckComponentEnabled(UInt32 SceneID, UInt64 uuid, string name_space, string name);
-        [DllImport("__Internal")] private static extern void SetComponentEnabled(UInt32 SceneID, UInt64 uuid, string name_space, string name, bool active);
-
-        public bool enabled
-        {
-            get
-            {
-                Type type = GetType();
-                string name = type.Name;
-                string name_space = "";
-                if (type.Namespace != null)
-                    name_space = type.Namespace;
-                return CheckComponentEnabled(gameObject.scene, gameObject.GetInstanceID(), name_space, name);
-            }
-            set
-            {
-                Type type = GetType();
-                string name = type.Name;
-                string name_space = "";
-                if (type.Namespace != null)
-                    name_space = type.Namespace;
-                SetComponentEnabled(gameObject.scene, gameObject.GetInstanceID(), name_space, name, value);
-            }
-        }
-
         public GameObject gameObject
         {
             get { return m_GameObject; }

--- a/Editor/vendor/scriptcore/src/ScriptCore/Components/MonoBehaviour.cs
+++ b/Editor/vendor/scriptcore/src/ScriptCore/Components/MonoBehaviour.cs
@@ -43,7 +43,7 @@ namespace Ouroboros
         [DllImport("__Internal")] private static extern void SetScriptEnabled(UInt32 sceneID, UInt64 uuid, string name_space, string name, bool enabled);
         [DllImport("__Internal")] private static extern bool CheckScriptEnabled(UInt32 sceneID, UInt64 uuid, string name_space, string name);
 
-        public new bool enabled
+        public bool enabled
         {
             get { return CheckScriptEnabled(gameObject.scene, gameObject.GetInstanceID(), GetType().Namespace ?? "", GetType().Name); ; }
             set { SetScriptEnabled(gameObject.scene, gameObject.GetInstanceID(), GetType().Namespace ?? "", GetType().Name, value); }

--- a/Editor/vendor/scriptcore/src/ScriptCore/Data/Prefab.cs
+++ b/Editor/vendor/scriptcore/src/ScriptCore/Data/Prefab.cs
@@ -28,5 +28,10 @@ namespace Ouroboros
                 return null;
             return GCHandle.FromIntPtr(ptr).Target as GameObject;
         }
+
+        public override string ToString()
+        {
+            return "Prefab(\"" + filePath + "\")";
+        }
     }
 }

--- a/Editor/vendor/scriptcore/src/ScriptCore/Data/Prefab.cs
+++ b/Editor/vendor/scriptcore/src/ScriptCore/Data/Prefab.cs
@@ -2,7 +2,7 @@
 
 namespace Ouroboros
 {
-    public struct Prefab
+    public class Prefab
     {
         private string filePath;
 
@@ -11,10 +11,20 @@ namespace Ouroboros
             this.filePath = filePath;
         }
 
+        [DllImport("__Internal")] private static extern bool CheckValidPrefabPath(string filePath);
+
+        public bool IsValid()
+        {
+            return CheckValidPrefabPath(filePath);
+        }
+
         [DllImport("__Internal")] private static extern System.IntPtr InstantiatePrefab(uint sceneID, string filePath, ulong parentID);
 
         public GameObject Instantiate()
         {
+            if(!IsValid())
+                throw new System.Exception("Prefab.Instantiate Invalid File Path: " + filePath);
+
             System.IntPtr ptr = InstantiatePrefab(SceneManager.GetActiveScene(), filePath, 0);
             if (ptr == System.IntPtr.Zero)
                 return null;
@@ -23,6 +33,9 @@ namespace Ouroboros
 
         public GameObject Instantiate(Transform parent)
         {
+            if (!IsValid())
+                throw new System.Exception("Prefab.Instantiate Invalid File Path: " + filePath);
+            
             System.IntPtr ptr = InstantiatePrefab(SceneManager.GetActiveScene(), filePath, parent.gameObject.GetInstanceID());
             if (ptr == System.IntPtr.Zero)
                 return null;

--- a/Editor/vendor/scripting/src/Scripting/ComponentDatabase.cpp
+++ b/Editor/vendor/scripting/src/Scripting/ComponentDatabase.cpp
@@ -24,15 +24,14 @@ namespace oo
     std::unordered_map<std::string, std::vector<std::string>> ComponentDatabase::inheritanceMap;
 
     void ComponentDatabase::RegisterComponent(std::string const& name_space, std::string const& name,
-        ComponentAction Add, ComponentAction Remove, ComponentCheck Has,
-        ComponentSetAction SetEnabled, ComponentCheck CheckEnabled)
+        ComponentAction Add, ComponentAction Remove, ComponentCheck Has)
     {
         std::string key = name_space + "." + name;
         componentTypeMap.emplace
         (
             key, ComponentType
             {
-                Add, Remove, Has, SetEnabled, CheckEnabled, name_space, name, componentTypeMap.size()
+                Add, Remove, Has, name_space, name, componentTypeMap.size()
             }
         );
     }
@@ -176,16 +175,6 @@ namespace oo
         if (object == nullptr)
             return InvalidPtr;
         return object->gameObject;
-    }
-
-    bool ComponentDatabase::CheckEnabled(UUID id, const char* name_space, const char* name)
-    {
-        return GetComponentType(name_space, name).CheckEnabled(sceneID, id);
-    }
-
-    void ComponentDatabase::SetEnabled(UUID id, const char* name_space, const char* name, bool isEnabled)
-    {
-        GetComponentType(name_space, name).SetEnabled(sceneID, id, isEnabled);
     }
 
     void ComponentDatabase::Delete(UUID id, const char* name_space, const char* name, bool onlyScript)

--- a/Editor/vendor/scripting/src/Scripting/ComponentDatabase.h
+++ b/Editor/vendor/scripting/src/Scripting/ComponentDatabase.h
@@ -38,7 +38,6 @@ namespace oo
 
         using ComponentAction = std::function<void(SceneID, UUID)>;
         using ComponentCheck = std::function<bool(SceneID, UUID)>;
-        using ComponentSetAction = std::function<void(SceneID, UUID, bool)>;
 
         static constexpr IntPtr InvalidPtr = 0;
 
@@ -48,8 +47,6 @@ namespace oo
             ComponentAction Add;
             ComponentAction Remove;
             ComponentCheck Has;
-            ComponentSetAction SetEnabled;
-            ComponentCheck CheckEnabled;
 
             std::string name_space;
             std::string name;
@@ -68,8 +65,7 @@ namespace oo
 
     public:
         static void RegisterComponent(std::string const& name_space, std::string const& name,
-            ComponentAction Add, ComponentAction Remove, ComponentCheck Has,
-            ComponentSetAction SetEnabled, ComponentCheck CheckEnabled);
+            ComponentAction Add, ComponentAction Remove, ComponentCheck Has);
 
         static size_t GetComponentTypeIndex(const char* name_space, const char* name);
 
@@ -120,9 +116,6 @@ namespace oo
                 return nullptr;
             return mono_gchandle_get_target(ptr);
         }
-
-        bool CheckEnabled(UUID id, const char* name_space, const char* name);
-        void SetEnabled(UUID id, const char* name_space, const char* name, bool isEnabled);
 
         void Delete(UUID id, const char* name_space, const char* name, bool onlyScript = false);
         void Delete(UUID id);

--- a/Editor/vendor/scripting/src/Scripting/ScriptEngine.cpp
+++ b/Editor/vendor/scripting/src/Scripting/ScriptEngine.cpp
@@ -38,7 +38,7 @@ namespace oo
         _pclose(msbuildPathFile);
 
         // execute build command
-        std::string command("\"\"" + msbuildPath + "\" \"" + projPath + "\" -noLogo -verbosity:quiet -t:Build -fl1 -flp1:logfile=\"" 
+        std::string command("\"\"" + msbuildPath + "\" \"" + projPath + "\" -noLogo -verbosity:quiet -t:Build -fl1 -p:nowarn=0649 -flp1:logfile=\"" 
                             + errorsPath + "\";errorsonly -fl2 -flp2:logfile=\"" + warningsPath 
                             + "\";warningsonly -p:Configuration=\"Debug OpenGL\";Platform=\"x64\"");
         FILE* compileResult = _popen(command.c_str(), "r");


### PR DESCRIPTION
- added auto-compile when focusing back to editor after making script changes
- removed C# component level enable/disable (not supported by engine)
- Added C# script OnApplicationFocus / OnApplicationPause function calls
- ignored C# variable not set warning (most of the time its set in inspector)

ScriptValue support for:
- C# Prefab (C++ prefab_type, just a filePath)
- C# AudioClip (C++ Asset)
actual serializer/inspector support sold separately