### PR TITLE
animation updates

### DIFF
--- a/Editor/src/App/Editor/UI/Object Editor/AssetBrowser.cpp
+++ b/Editor/src/App/Editor/UI/Object Editor/AssetBrowser.cpp
@@ -32,6 +32,9 @@ void AssetBrowser::AssetPickerUI(rttr::variant& data, bool& edited,int asset_typ
 		AudioUI(data, edited); break;
 	case oo::AssetInfo::Type::Model:
 		MeshUI(data, edited); break;
+	case oo::AssetInfo::Type::AnimationTree:
+		AnimationTreeUI(data, edited); break;
+
 	}
 	ImGui::EndChild();
 }
@@ -147,4 +150,20 @@ void AssetBrowser::MeshUI(rttr::variant& data, bool& edited)
 		}*/
 	}
 
+}
+
+void AssetBrowser::AnimationTreeUI(rttr::variant& data, bool& edited)
+{
+	ImVec2 windowSize = ImGui::GetContentRegionAvail();
+	ImVec2 spacing = ImGui::GetStyle().ItemSpacing;
+
+	for (const auto& assets : Project::GetAssetManager()->GetAssetsByType(oo::AssetInfo::Type::AnimationTree))
+	{
+		if (ImGui::Selectable(assets.GetFilePath().stem().string().c_str()))
+		{
+			data.clear();
+			data = assets;
+			edited = true;
+		}
+	}
 }

--- a/Editor/src/App/Editor/UI/Object Editor/AssetBrowser.h
+++ b/Editor/src/App/Editor/UI/Object Editor/AssetBrowser.h
@@ -23,4 +23,5 @@ private:
 	static void FontUI(rttr::variant& data, bool& edited);
 	static void AudioUI(rttr::variant& data, bool& edited);
 	static void MeshUI(rttr::variant& data, bool& edited);
+	static void AnimationTreeUI(rttr::variant& data, bool& edited);
 };

--- a/Editor/src/App/Editor/UI/Object Editor/FileBrowser.cpp
+++ b/Editor/src/App/Editor/UI/Object Editor/FileBrowser.cpp
@@ -269,7 +269,6 @@ void FileBrowser::PopupOptions()
 		}
 		if (ImGui::MenuItem("Create Animation Tree"))
 		{
-			//oo::AnimatorController::CreateNewControllerAsset();
 			oo::Anim::AnimationSystem::CreateAnimationTree("New Animation Tree");
 		}
 		if (ImGui::MenuItem("Create Animation"))

--- a/Editor/src/App/Editor/UI/Tools/AnimatorControllerView.cpp
+++ b/Editor/src/App/Editor/UI/Tools/AnimatorControllerView.cpp
@@ -90,32 +90,50 @@ void AnimatorControllerView::DisplayAnimatorController(oo::AnimationComponent* _
     ed::SetCurrentEditor(m_Context);
     ed::Begin("Animator Controller Editor", ImVec2(0.0, 0.0));
 
-    if (!_animator)
+    if (!_animator || _animator->HasAnimationTree() == false)
     {
         ed::End();
         return;
     }
 
-    if (!_animator->GetActualComponent().animTree)
-    {
-        auto tree = oo::Anim::AnimationSystem::CreateAnimationTree("Test Animation Tree");
-        (void)(tree);
-        _animator->SetAnimationTree("Test Animation Tree");
-        //auto& start_node = tree->groups.begin()->second.startNode;
-    }
+    //if (!_animator->GetActualComponent().animTree)
+    //{
+    //    auto tree = oo::Anim::AnimationSystem::CreateAnimationTree("Test Animation Tree");
+    //    (void)(tree);
+    //    _animator->SetAnimationTree("Test Animation Tree");
+    //    //auto& start_node = tree->groups.begin()->second.startNode;
+    //}
 
     //Handle for everytime i press a new animatortree
-    if (m_firstFrame)
+    //if (m_firstFrame)
+    if constexpr (true)
     {
         //initialize the node editor with data from animation tree
         if (!_animator->GetActualComponent().animTree->groups.empty())
         {
-            auto& temp = _animator->GetActualComponent().animTree->groups;
-            for (auto it = temp.begin(); it != temp.end(); ++it)
+            //reset the data before populating
+            m_nodes.clear();
+            m_links_.clear();
+
+            auto& groups = _animator->GetActualComponent().animTree->groups;
+            for (auto& [groupID, group] : groups)
             {
-                for (auto it2 = it->second.nodes.begin(); it2 != it->second.nodes.end(); ++it2)
+                for (auto& [nodeID, node] : group.nodes)
                 {
-                    CreateNode(uniqueId, &it2->second);
+                    CreateNode(uniqueId, &node);
+                }
+
+                for (auto& [linkID, link] : group.links)
+                {
+                    NodeInfo* outputNode = FindNode(link.src.operator->());
+                    NodeInfo* inputNode = FindNode(link.dst.operator->());
+
+                    ed::PinId inputPin = outputNode->Output[0].id;
+                    ed::PinId outputPin = inputNode->Input[0].id;
+
+                    m_links_.push_back(LinkInfo(ed::LinkId(m_nextLinkId++), inputPin, outputPin));
+                    m_links_.back().link = &link;
+                    ed::Link(m_links_.back().id, m_links_.back().inputID, m_links_.back().outputID);
                 }
             }
         }
@@ -147,7 +165,7 @@ void AnimatorControllerView::DisplayAnimatorController(oo::AnimationComponent* _
         ed::Link(LinkInfo.id, LinkInfo.inputID, LinkInfo.outputID);
     }
 
-    if (m_firstFrame)
+    /*if (m_firstFrame)
     {
         auto& temp = _animator->GetActualComponent().animTree->groups;
         for (auto it = temp.begin(); it != temp.end(); ++it)
@@ -165,7 +183,7 @@ void AnimatorControllerView::DisplayAnimatorController(oo::AnimationComponent* _
                 ed::Link(m_links_.back().id, m_links_.back().inputID, m_links_.back().outputID);
             }
         }
-    }
+    }*/
 
 
     //
@@ -466,6 +484,12 @@ void AnimatorControllerView::DisplayInspector()
             {
                 ed::NodeId temp = m_nodesId[i];
                 auto id = std::find_if(m_nodes.begin(), m_nodes.end(), [temp](auto& node) { return node.id == temp; });
+                
+                //do nothing if no found in m_nodes
+                if (id == m_nodes.end()) continue;
+                //do nothing if no animation assigned for now
+                if (id->anim_node->HasAnimation() == false) continue;
+
                 ImGui::Text("Name");
                 ImVec2 textsize = ImGui::CalcTextSize("a");
                 ImGui::SameLine(textsize.x * 8);

--- a/Editor/src/Ouroboros/Animation/Anim_Utils.h
+++ b/Editor/src/Ouroboros/Animation/Anim_Utils.h
@@ -52,6 +52,14 @@ namespace oo::Anim
 	using P_TYPE = ParamType;
 	//using ParameterValueType = std::variant<bool, int, float>;
 
+	struct UID
+	{
+		size_t id{};
+		UID() = default;
+		operator size_t() const { return id; }
+		UID(size_t _id) : id{_id}{}
+	};
+
 	struct InvalidType {};
 	//variables that are defined within an AnimationTree that can be accessed and assigned values from scripts or editor
 	struct Parameter;	

--- a/Editor/src/Ouroboros/Animation/AnimationComponent.cpp
+++ b/Editor/src/Ouroboros/Animation/AnimationComponent.cpp
@@ -57,7 +57,9 @@ namespace oo
 
 	void oo::AnimationComponent::SetAnimationTree(oo::Asset asset)
 	{
-		auto treeID = asset.GetData<size_t>();
+		if (asset.IsValid() == false) return;
+
+		auto treeID = asset.GetData<Anim::UID>();
 		SetAnimationTree(treeID);
 		//if failed to find animation tree
 		if (HasAnimationTree() == false) return;

--- a/Editor/src/Ouroboros/Animation/AnimationInternal.cpp
+++ b/Editor/src/Ouroboros/Animation/AnimationInternal.cpp
@@ -40,6 +40,7 @@ std::unordered_map <rttr::type::type_id, StringHash::size_type> oo::Anim::intern
 	add(rttr::type::get<float>(), "float");
 	add(rttr::type::get<int>(), "int");
 	add(rttr::type::get<size_t>(), "size_t");
+	add(rttr::type::get<oo::Anim::UID>(), "UID");
 	add(rttr::type::get<std::string>(), "std::string");
 	add(rttr::type::get<glm::vec3>(), "glm::vec3");
 	add(rttr::type::get<glm::quat>(), "glm::quat");
@@ -72,7 +73,11 @@ std::unordered_map<rttr::type::type_id, oo::Anim::internal::SerializeFn*> oo::An
 	{
 		writer.Uint64(val.get_value<size_t>());
 	};
-
+	map[rttr::type::get<oo::Anim::UID>().get_id()]
+		= [](rapidjson::PrettyWriter<rapidjson::OStreamWrapper>& writer, rttr::variant& val)
+	{
+		writer.Uint64(val.get_value<oo::Anim::UID>());
+	};
 	//rttr types
 	map[rttr::type::get<rttr::variant>().get_id()]
 		= [](rapidjson::PrettyWriter<rapidjson::OStreamWrapper>& writer, rttr::variant& val)
@@ -273,6 +278,16 @@ std::unordered_map<rttr::type::type_id, oo::Anim::internal::SerializeFn*> oo::An
 		writer.Uint64(val.get_value<size_t>());
 		writer.EndObject();
 	};
+	map[rttr::type::get<oo::Anim::UID>().get_id()]
+		= [](rapidjson::PrettyWriter<rapidjson::OStreamWrapper>& writer, rttr::variant& val)
+	{
+		writer.StartObject();
+		writer.Key("Type Hash", static_cast<rapidjson::SizeType>(std::string("Type Hash").size()));
+		writer.Uint64(static_cast<uint64_t>(rttrType_to_hash[rttr::type::get<oo::Anim::UID>().get_id()]));
+		writer.Key("Value", static_cast<rapidjson::SizeType>(std::string("Value").size()));
+		writer.Uint64(val.get_value<oo::Anim::UID>());
+		writer.EndObject();
+	};
 	map[rttr::type::get<std::string>().get_id()]
 		= [](rapidjson::PrettyWriter<rapidjson::OStreamWrapper>& writer, rttr::variant& val)
 	{
@@ -334,6 +349,11 @@ std::unordered_map<rttr::type::type_id, oo::Anim::internal::LoadFn*> oo::Anim::i
 		= [](rapidjson::Value& value)
 	{
 		return rttr::variant{ value.GetUint64() };
+	};
+	map[rttr::type::get<oo::Anim::UID>().get_id()]
+		= [](rapidjson::Value& value)
+	{
+		return rttr::variant{ oo::Anim::UID{value.GetUint64()} };
 	};
 	map[rttr::type::get<std::string>().get_id()]
 		= [](rapidjson::Value& value)
@@ -505,6 +525,13 @@ std::unordered_map<rttr::type::type_id, oo::Anim::internal::LoadFn*> oo::Anim::i
 	{
 		auto val = static_cast<size_t>(value.GetUint64());
 		return rttr::variant{ val };
+	};
+
+	map[rttr::type::get<oo::Anim::UID>().get_id()]
+		= [](rapidjson::Value& value)
+	{
+		auto val = static_cast<size_t>(value.GetUint64());
+		return rttr::variant{ oo::Anim::UID{val} };
 	};
 
 	map[rttr::type::get<std::string>().get_id()]

--- a/Editor/src/Ouroboros/Animation/AnimationNode.cpp
+++ b/Editor/src/Ouroboros/Animation/AnimationNode.cpp
@@ -143,10 +143,14 @@ namespace oo::Anim
 		, name{ info.name }
 		, node_ID{ info.nodeID == internal::invalid_ID ? internal::generateUID() : info.nodeID }
 	{
-		assert(Animation::name_to_ID.contains(info.animation_name));
+		auto anim_ptr = internal::RetrieveAnimation(info.animation_name);
+		if (anim_ptr == nullptr)
+		{
+			return;
+		}
+
 		anim.anims = &(Animation::animation_storage);
-		anim.id = Animation::animation_storage[
-			Animation::name_to_ID[info.animation_name]].animation_ID;
+		anim.id = anim_ptr->animation_ID;
 		anim.Reload();
 	}
 
@@ -155,5 +159,9 @@ namespace oo::Anim
 	{
 		assert(anim);
 		return *anim;
+	}
+	bool oo::Anim::Node::HasAnimation()
+	{
+		return anim;
 	}
 }

--- a/Editor/src/Ouroboros/Animation/AnimationNode.h
+++ b/Editor/src/Ouroboros/Animation/AnimationNode.h
@@ -50,6 +50,7 @@ namespace oo::Anim
 		//void SetAnimation(Asset asset);
 		//void SetAnimation(Asset asset);
 		Animation& GetAnimation();
+		bool HasAnimation();
 
 		RTTR_ENABLE();
 	};

--- a/Editor/src/Ouroboros/Animation/AnimationTree.h
+++ b/Editor/src/Ouroboros/Animation/AnimationTree.h
@@ -32,7 +32,7 @@ namespace oo::Anim
 		std::unordered_map<size_t, uint> paramIDtoIndexMap;
 		//std::vector<Animation> animations;
 		//std::vector<Node> nodes;
-		size_t treeID{ internal::invalid_ID };
+		UID treeID{ internal::invalid_ID };
 
 	
 		RTTR_ENABLE();

--- a/Editor/src/Ouroboros/Asset/Asset.cpp
+++ b/Editor/src/Ouroboros/Asset/Asset.cpp
@@ -151,6 +151,7 @@ namespace oo
                     using namespace Anim;
                     Animation* anim = AnimationSystem::LoadAnimation(self.contentPath.string());
                     self.data.emplace_back(anim->name);
+                    self.data.emplace_back(anim->animation_ID);
                 };
                 onAssetDestroy = [](AssetInfo& self) {};
                 break;
@@ -163,6 +164,7 @@ namespace oo
                     using namespace Anim;
                     AnimationTree* animTree = AnimationSystem::LoadAnimationTree(self.contentPath.string());
                     self.data.emplace_back(animTree->name);
+                    self.data.emplace_back(animTree->treeID);
                 };
                 onAssetDestroy = [](AssetInfo& self) {};
                 break;


### PR DESCRIPTION
bugfixes:
Animation tree UI:
DisplayAnimatorController just does nothing if _animator->HasAnimationTree() == false querying for node and link data to populate m_nodes and m_links_ is now done every frame instead of just the first frame skip displaying node information in inspector if animation is not assigned

updates:
animation tree assets to show up in asset browser and can be assigned to component

not important for anyone to know:
added animation tree UID to be stored as asset data