### PR TITLE
animation updates

### DIFF
--- a/Editor/src/App/Editor/UI/Tools/MeshHierarchy.cpp
+++ b/Editor/src/App/Editor/UI/Tools/MeshHierarchy.cpp
@@ -33,6 +33,8 @@ Technology is prohibited.
 #include "SceneManagement/include/SceneManager.h"
 #include "Ouroboros/Vulkan/SkinRendererComponent.h"
 #include "Ouroboros/Transform/TransformSystem.h"
+#include "Ouroboros/Animation/Animation.h"
+#include "Ouroboros/Animation/AnimationSystem.h"
 MeshHierarchy::MeshHierarchy()
 {
 	oo::EventManager::Subscribe<MeshHierarchy, OpenFileEvent>(this, &MeshHierarchy::OpenFileCallBack);
@@ -132,6 +134,11 @@ void MeshHierarchy::Show()
 	if(ImGui::Button("Add Whole Mesh"))
 	{
 		CreateObject(modeldata->sceneInfo,m_current_id);
+	}
+	if (ImGui::Button("Generate Animation"))
+	{
+		auto anims = oo::Anim::AnimationSystem::LoadAnimationFromFBX(asset.GetFilePath().string(), modeldata);
+
 	}
 }
 

--- a/Editor/src/Ouroboros/Animation/Anim_Utils.h
+++ b/Editor/src/Ouroboros/Animation/Anim_Utils.h
@@ -83,6 +83,7 @@ namespace oo::Anim
 	struct AnimationTree; 
 	struct AnimationTracker; //tracks a user's progress in an animation tree
 	struct ProgressTracker;
+	struct ScriptEventTracker;
 	class IAnimationComponent;
 	class AnimationSystem;
 
@@ -102,6 +103,12 @@ namespace oo::Anim
 		{
 			UpdateTrackerInfo& tracker_info;
 			ProgressTracker& progressTracker;
+		};
+
+		struct UpdateScriptEventInfo
+		{
+			UpdateTrackerInfo& tracker_info;
+			std::vector<ScriptEvent>& events;
 		};
 
 		constexpr char  serialize_method_name[] = "Serialize";

--- a/Editor/src/Ouroboros/Animation/Animation.cpp
+++ b/Editor/src/Ouroboros/Animation/Animation.cpp
@@ -398,6 +398,9 @@ namespace oo::Anim
 		//remove existing dupe
 		if (Animation::name_to_ID.contains(anim.name))
 		{
+			auto old_anim = internal::RetrieveAnimation(Animation::name_to_ID[anim.name]);
+			assert(old_anim);
+			//anim.animation_ID = old_anim->animation_ID;
 			RemoveAnimation(anim.name);
 		}
 

--- a/Editor/src/Ouroboros/Animation/AnimationInternal.h
+++ b/Editor/src/Ouroboros/Animation/AnimationInternal.h
@@ -56,16 +56,15 @@ namespace oo::Anim::internal
 	void TriggerEvent(UpdateProgressTrackerInfo& info, ScriptEvent& event);
 	KeyFrame::DataType GetInterpolatedValue(rttr::type rttr_type, KeyFrame::DataType prev, KeyFrame::DataType next, float percentage);
 
-	//void UpdateEvent(AnimationComponent& comp, AnimationTracker& tracker, ProgressTracker& progressTracker, float updatedTimer)
-	void UpdateEvent(UpdateProgressTrackerInfo& info, float updatedTimer);
 
-	//void UpdateProperty_Animation(AnimationComponent& comp, AnimationTracker& tracker, ProgressTracker& progressTracker, float updatedTimer)
+
 	void UpdateProperty_Animation(UpdateProgressTrackerInfo& info, float updatedTimer);
 
-	//void UpdateFBX_Animation(AnimationComponent& comp, AnimationTracker& tracker, ProgressTracker& progressTracker, float updatedTimer)
 	void UpdateFBX_Animation(UpdateProgressTrackerInfo& info, float updatedTimer);
 	//go through all progress trackers and call their update function
 	void UpdateTrackerKeyframeProgress(UpdateTrackerInfo& info, float updatedTimer);
+
+	void UpdateScriptEventProgress(UpdateTrackerInfo& info, float updatedTimer);
 
 	KeyFrame* GetCurrentKeyFrame(ProgressTracker& tracker);
 

--- a/Editor/src/Ouroboros/Animation/AnimationNode.h
+++ b/Editor/src/Ouroboros/Animation/AnimationNode.h
@@ -40,6 +40,7 @@ namespace oo::Anim
 
 		//trackers to be given to the animation component 
 		//upon reaching this node
+		ScriptEventTracker scripteventTracker{};
 		std::vector<ProgressTracker> trackers{};
 		//outgoing links to other nodes
 		std::vector<LinkRef> outgoingLinks{};

--- a/Editor/src/Ouroboros/Animation/AnimationSystem.h
+++ b/Editor/src/Ouroboros/Animation/AnimationSystem.h
@@ -55,6 +55,9 @@ namespace oo::Anim
 		static bool SaveAllAnimationTree(std::string filepath);
 		static AnimationTree* LoadAnimationTree(std::string filepath);
 		static Animation* LoadAnimation(std::string filepath);
+		static std::vector<Animation*> LoadAnimationFromFBX(std::string const& filepath, ModelFileResource* resource);
+		static bool DeleteAnimation(std::string const& name);
+
 		static bool LoadAssets(std::string filepath);
 		static void OpenFileCallback(OpenFileEvent* evnt);
 		static void CloseProjectCallback(CloseProjectEvent* evnt);

--- a/Editor/src/Ouroboros/Animation/AnimationTimeline.cpp
+++ b/Editor/src/Ouroboros/Animation/AnimationTimeline.cpp
@@ -172,7 +172,8 @@ namespace oo::Anim
 			tracker.updatefunction = &internal::UpdateFBX_Animation;
 			break;
 		case Timeline::TYPE::SCRIPT_EVENT:
-			tracker.updatefunction = &internal::UpdateEvent;
+			assert(false);//it shouldnt hit this
+			//tracker.updatefunction = &internal::UpdateEvent;
 			break;
 		default:
 			break;

--- a/Editor/src/Ouroboros/Animation/AnimationTimeline.h
+++ b/Editor/src/Ouroboros/Animation/AnimationTimeline.h
@@ -86,4 +86,11 @@ namespace oo::Anim
 		ProgressTracker(const Timeline::TYPE _type);
 		static ProgressTracker Create(Timeline::TYPE type);
 	};
+
+	//trcks progress in 1 script event "timeline"
+	struct ScriptEventTracker
+	{
+		size_t nextEvent_index{ 0ul };	//index of next script event to call
+		std::vector<ScriptEvent>* events{nullptr};
+	};
 }

--- a/Editor/src/Ouroboros/Animation/AnimationTracker.h
+++ b/Editor/src/Ouroboros/Animation/AnimationTracker.h
@@ -40,8 +40,9 @@ namespace oo::Anim
 
 		InTransitionInfo transition_info{};
 
-		//event tracker, then FBX animations, then properties
-		//these track the various timelines in a single animation
+		//event tracker
+		ScriptEventTracker scripteventTracker{};
+		//these track the various timelines in a single animation for FBX and properties
 		std::vector<ProgressTracker> trackers;
 		//a copy of the animation tree's parameters to be used for this
 		//component only

--- a/Editor/src/Ouroboros/Asset/Asset.cpp
+++ b/Editor/src/Ouroboros/Asset/Asset.cpp
@@ -132,13 +132,13 @@ namespace oo
                     auto sp = std::shared_ptr<ModelFileResource>(vr->LoadModelFromFile(self.contentPath.string()));
                     self.data.emplace_back(sp);
 
-                    auto anims = Anim::Animation::LoadAnimationFromFBX(self.contentPath.string(), sp.get());
+                    /*auto anims = Anim::LoadAnimationFromFBX::LoadAnimationFromFBX(self.contentPath.string(), sp.get());
                     auto v = std::vector<std::string>();
                     for (auto& anim : anims)
                     {
                         v.emplace_back(anim->name);
                     }
-                    self.data.emplace_back(v);
+                    self.data.emplace_back(v);*/
                 };
                 onAssetDestroy = [](AssetInfo& self) {};
                 break;

--- a/Editor/src/Ouroboros/Vulkan/SkinRendererSystem.cpp
+++ b/Editor/src/Ouroboros/Vulkan/SkinRendererSystem.cpp
@@ -15,6 +15,9 @@ namespace oo
 		m_world->SubscribeOnAddComponent<SkinMeshRendererSystem, SkinMeshRendererComponent>(
 			this, &SkinMeshRendererSystem::OnMeshAssign);
 
+
+		m_world->SubscribeOnRemoveComponent<SkinMeshRendererSystem, SkinMeshRendererComponent>(
+			this, &SkinMeshRendererSystem::OnMeshRemove);
 	}
 
 	void RecurseChildren_AssignparentTransform_to_BoneComponents(GameObject obj, glm::mat4 parentTransform)
@@ -109,6 +112,11 @@ namespace oo
 			{
 				auto& gfx_Object = m_graphicsWorld->GetObjectInstance(m_comp.graphicsWorld_ID);
 				
+				gfx_Object.modelID = m_comp.meshResource;
+				gfx_Object.bindlessGlobalTextureIndex_Albedo = m_comp.albedoID;
+				gfx_Object.bindlessGlobalTextureIndex_Normal = m_comp.normalID;
+				gfx_Object.submesh = m_comp.meshInfo.submeshBits;
+
 				if (gfx_Object.bones.size() != m_comp.num_bones)
 					gfx_Object.bones.resize(m_comp.num_bones);
 			});
@@ -180,8 +188,15 @@ namespace oo
 		//update initial position
 		auto& graphics_object = m_graphicsWorld->GetObjectInstance(meshComp.graphicsWorld_ID);
 		graphics_object.localToWorld = transform_component.GetGlobalMatrix();
-		graphics_object.flags = ObjectInstanceFlags::SKINNED;
+		graphics_object.flags = ObjectInstanceFlags::SKINNED | ObjectInstanceFlags::RENDER_ENABLED;
 
 		meshComp.gfx_Object = &graphics_object;
+	}
+	void SkinMeshRendererSystem::OnMeshRemove(Ecs::ComponentEvent<SkinMeshRendererComponent>* evnt)
+	{
+		auto& comp = evnt->component;
+		m_graphicsWorld->DestroyObjectInstance(comp.graphicsWorld_ID);
+		// remove graphics id to uuid of gameobject
+		//m_graphicsIdToUUID.erase(comp.GraphicsWorldID);
 	}
 }

--- a/Editor/src/Ouroboros/Vulkan/SkinRendererSystem.h
+++ b/Editor/src/Ouroboros/Vulkan/SkinRendererSystem.h
@@ -13,7 +13,7 @@ namespace oo
 		oo::Scene* scene{nullptr};
 	public:
 		SkinMeshRendererSystem(GraphicsWorld* graphicsWorld, oo::Scene* _scene);
-
+		
 		void Init();
 
 		virtual void Run(Ecs::ECSWorld* world) override;
@@ -22,5 +22,6 @@ namespace oo
 	private:
 		void AssignGraphicsWorldID_to_BoneComponents(oo::Scene& scene);
 		void OnMeshAssign(Ecs::ComponentEvent<SkinMeshRendererComponent>* evnt);
+		void OnMeshRemove(Ecs::ComponentEvent<SkinMeshRendererComponent>* evnt);
 	};
 }


### PR DESCRIPTION
loading an animation that already exists will replace current one

skin mesh on destroy component callback

anim serialization fix

script events should trigger now

skin mesh renderer fixes

disabled loading animations from fbx automatically

generate animation button available

animation script event update

skinned mesh added enable render flags